### PR TITLE
Fixed typo in options that didn't respect input data path in Asis_Tester

### DIFF
--- a/Asis/Tester.php
+++ b/Asis/Tester.php
@@ -44,7 +44,7 @@ class Asis_Tester
         if (!$this->_inputDataProvider)
             $this->_inputDataProvider = new Asis_Common_InputDataProvider(
                 array(
-                    'fullTemplatesPath' => $this->_config['inputDataPath'],
+                    'inputDataPath' => $this->_config['inputDataPath'],
                     "inputExtension" => $this->_config['inputExtension']
                 )
             );


### PR DESCRIPTION
The Tester wasn't properly creating files in the `outputDataPath` I defined, debugging the code I found that this option was set incorrectly, or at least I could not find mention of `fullTemplatesPath` anywhere else in the code, so I replaced it with `inputDataPath` and then my output data files were generated correctly.
